### PR TITLE
fix(JobApiCall): prevent crash if numberParallel parameter is greater than the number of files in the repository

### DIFF
--- a/src/Ml.Cli/JobApiCall/Job.cs
+++ b/src/Ml.Cli/JobApiCall/Job.cs
@@ -33,7 +33,7 @@ namespace Ml.Cli.JobApiCall
         {
             return source
                 .Select((x, i) => new { Index = i, Value = x })
-                .GroupBy(x => x.Index / chunkSize)
+                .GroupBy(x => x.Index / (chunkSize == 0 ? 1 : chunkSize))
                 .Select(x => x.Select(v => v.Value).ToList())
                 .ToList();
         }


### PR DESCRIPTION
closes #172 