### PR TITLE
fix(Projects): board filters now working correctly

### DIFF
--- a/src/Ml.Cli.WebApp/ClientApp/src/Server/Project/List/ColumnHeader.js
+++ b/src/Ml.Cli.WebApp/ClientApp/src/Server/Project/List/ColumnHeader.js
@@ -10,12 +10,14 @@ const HeaderColumnCell = ({ onChangeSort, headerColumnName, filterColumnValue })
       <span className="af-table__th-content">
         <Button className="af-btn" classModifier="table-sorting" onClick={onChangeSort}>
           <span className="af-btn__text">{headerColumnName}</span>
-          <i
-            className={
-              'glyphicon ' +
-              (filterColumnValue === null ? 'glyphicon-sorting' : `glyphicon-sorting-${filterColumnValue}`)
-            }
-          />
+          {filterColumnValue !== undefined &&
+              <i
+                  className={
+                      'glyphicon ' +
+                      (filterColumnValue === null ? 'glyphicon-sorting' : `glyphicon-sorting-${filterColumnValue}`)
+                  }
+              />
+          }
         </Button>
       </span>
     </Table.Th>

--- a/src/Ml.Cli.WebApp/ClientApp/src/Server/Project/List/Home.reducer.js
+++ b/src/Ml.Cli.WebApp/ClientApp/src/Server/Project/List/Home.reducer.js
@@ -62,6 +62,7 @@ export const reducer = (state, action) => {
         property.timeLastUpdate = new Date().getTime();
       } else if (value === 'desc') {
         property.value = 'asc';
+        property.timeLastUpdate = new Date().getTime();
       } else {
         property.value = null;
         property.timeLastUpdate = null;
@@ -92,8 +93,7 @@ export const initialState = {
       name: { value: null, timeLastUpdate: null },
       groupName: {value: null, timeLastUpdate: null},
       createDate: { value: 'desc', timeLastUpdate: new Date() },
-      annotationType: { value: null, timeLastUpdate: null },
-      numberCrossAnnotation: { value: null, timeLastUpdate: null },
+      annotationType: { value: null, timeLastUpdate: null }
     },
   },
 };

--- a/src/Ml.Cli.WebApp/ClientApp/src/Server/Project/List/ItemsTable.js
+++ b/src/Ml.Cli.WebApp/ClientApp/src/Server/Project/List/ItemsTable.js
@@ -11,8 +11,6 @@ import {
 } from '@axa-fr/react-toolkit-all';
 import {ProgressBar} from "./ProgressBar";
 
-
-
 const NumberTagToDo = ({state}) =>{
     const {ERROR, SUCCESS, LOADING} = resilienceStatus;
     const annotationsStatus = state.annotationsStatus;
@@ -134,9 +132,7 @@ const ItemsTable = ({items, filters, onChangePaging, onChangeSort, fetch}) => {
                             filterColumnValue={filters.columns.annotationType.value}
                         />
                         <HeaderColumnCell
-                            onChangeSort={onChangeSort('numberTagToDo')}
                             headerColumnName={'Status'}
-                            filterColumnValue={filters.columns.numberCrossAnnotation.value}
                         />
                         <Table.Th classModifier="sortable">
                             <span className="af-table__th-content af-btn__text">Action</span>

--- a/src/Ml.Cli.WebApp/ClientApp/src/Server/Project/List/ItemsTable.spec.js
+++ b/src/Ml.Cli.WebApp/ClientApp/src/Server/Project/List/ItemsTable.spec.js
@@ -22,8 +22,7 @@ const filters = {
         groupName: {value: null, timeLastUpdate: null},
         createDate: { value: 'desc', timeLastUpdate: new Date() },
         annotationType: { value: null, timeLastUpdate: null },
-        numberTagToDo: { value: null, timeLastUpdate: null },
-        numberCrossAnnotation: {value: null}
+        numberTagToDo: { value: null, timeLastUpdate: null }
     },
 };
 

--- a/src/Ml.Cli.WebApp/ClientApp/src/Server/Project/List/__snapshots__/Home.container.spec.js.snap
+++ b/src/Ml.Cli.WebApp/ClientApp/src/Server/Project/List/__snapshots__/Home.container.spec.js.snap
@@ -199,9 +199,6 @@ exports[`Home.container HomeContainer render correctly 1`] = `
                 >
                   Status
                 </span>
-                <i
-                  class="glyphicon glyphicon-sorting"
-                />
               </button>
             </span>
           </th>

--- a/src/Ml.Cli.WebApp/ClientApp/src/Server/Project/List/__snapshots__/ItemsTable.spec.js.snap
+++ b/src/Ml.Cli.WebApp/ClientApp/src/Server/Project/List/__snapshots__/ItemsTable.spec.js.snap
@@ -110,9 +110,6 @@ exports[`Check Project ItemsTable behaviour Chould render correctly 1`] = `
               >
                 Status
               </span>
-              <i
-                class="glyphicon glyphicon-sorting"
-              />
             </button>
           </span>
         </th>


### PR DESCRIPTION
It's impossible to add a filter on the status column, as its values are recovered directly in the row and not in the whole board. It means that a row does not know the values of other rows, so it is impossible to sort them.